### PR TITLE
Feat: Add Uninstall Page with Feedback Form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env.local

--- a/app/uninstall/page.tsx
+++ b/app/uninstall/page.tsx
@@ -55,7 +55,7 @@ export default function UninstallPage() {
         setError("")
 
         try {
-            // Replace with your Web3Forms access key from https://web3forms.com
+            // Call Web3Forms directly (they're designed for client-side use)
             const response = await fetch("https://api.web3forms.com/submit", {
                 method: "POST",
                 headers: {
@@ -63,7 +63,7 @@ export default function UninstallPage() {
                     Accept: "application/json",
                 },
                 body: JSON.stringify({
-                    access_key: "5cc7d0eb-fbcb-4205-bb25-46b717696aa7", // Get this from https://web3forms.com
+                    access_key: process.env.NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY,
                     subject: "Locksy Extension Uninstall Feedback",
                     from_name: "Locksy Uninstall Page",
                     reasons: selectedReasons.join(", "),


### PR DESCRIPTION
…n optionsThis PR introduces a new uninstall page (`/uninstall`) for the Locksy extension. The page includes a feedback form to gather user reasons for uninstalling, an option to quickly reinstall the extension, highlights of features users might miss, solutions to common issues, and a clear call to action to reinstall. It also adds `.env.local` to `.gitignore`.